### PR TITLE
Stacks support no options

### DIFF
--- a/lib/divo/stack.ex
+++ b/lib/divo/stack.ex
@@ -29,11 +29,13 @@ defmodule Divo.Stack do
 
     services =
       config
-      |> Enum.map(fn {module, envars} ->
-        apply(module, :gen_stack, [envars])
-      end)
+      |> Enum.map(&configure_stack/1)
       |> Enum.reduce(%{}, fn service, acc -> Map.merge(service, acc) end)
 
     Map.put(compose_file, :services, services)
   end
+
+  defp configure_stack(module) when is_atom(module), do: apply(module, :gen_stack, [[]])
+
+  defp configure_stack({module, envars}), do: apply(module, :gen_stack, [envars])
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Divo.MixProject do
   def project do
     [
       app: :divo,
-      version: "1.1.1",
+      version: "1.1.2",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/stack_test.exs
+++ b/test/stack_test.exs
@@ -2,7 +2,7 @@ defmodule Divo.StackTest do
   use ExUnit.Case
   require TemporaryEnv
 
-  test "behaviour returns the service definition" do
+  test "behaviour returns the service definition of a single stack" do
     services = [
       {DivoFoobar, [db_password: "we-are-divo", db_name: "foobar-db", something: "else"]}
     ]
@@ -21,6 +21,29 @@ defmodule Divo.StackTest do
             "PASSWORD=we-are-divo",
             "DB=foobar-db"
           ]
+        }
+      }
+    }
+
+    actual = Divo.Stack.concat_compose(services)
+
+    assert expected == actual
+  end
+
+  test "behaviour returns the service definition of a stack with no parameters" do
+    services = [
+      DivoBarbaz
+    ]
+
+    expected = %{
+      version: "3.4",
+      services: %{
+        barbaz: %{
+          image: "library/barbaz",
+          ports: ["2345:2345", "7777:7777"],
+          healthcheck: %{
+            test: ["CMD-SHELL", "/bin/true || exit 1"]
+          }
         }
       }
     }
@@ -51,6 +74,23 @@ defmodule DivoFoobar do
           "PASSWORD=#{password}",
           "DB=#{db_name}"
         ]
+      }
+    }
+  end
+end
+
+defmodule DivoBarbaz do
+  @behaviour Divo.Stack
+
+  @impl Divo.Stack
+  def gen_stack(_envars) do
+    %{
+      barbaz: %{
+        image: "library/barbaz",
+        healthcheck: %{
+          test: ["CMD-SHELL", "/bin/true || exit 1"]
+        },
+        ports: ["2345:2345", "7777:7777"]
       }
     }
   end


### PR DESCRIPTION
This cleans up the implementation a little to allow easier adding of stacks that don't require or take any arguments. For a composite of one stack that takes envar arguments and another that doesn't mix config would look like this:
```
config :myapp,
  divo: [
    {DivoStackOne, [config: "thing", other_config: "other_thing"]},
    DivoStackTwo
  ]
```